### PR TITLE
Switch to RabbitMQ for MassTransit transport

### DIFF
--- a/src/Sample.Api/Sample.Api.csproj
+++ b/src/Sample.Api/Sample.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit.SqlTransport.PostgreSQL" Version="8.3.2" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sample.AppHost/HealthCheckAnnotation.cs
+++ b/src/Sample.AppHost/HealthCheckAnnotation.cs
@@ -1,8 +1,7 @@
-namespace Sample.AppHost;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-
+namespace Sample.AppHost;
 public class HealthCheckAnnotation(Func<IResource, CancellationToken, Task<IHealthCheck?>> healthCheckFactory) : IResourceAnnotation
 {
     public Func<IResource, CancellationToken, Task<IHealthCheck?>> HealthCheckFactory { get; } = healthCheckFactory;

--- a/src/Sample.AppHost/PostgreSqlHealthCheckExtensions.cs
+++ b/src/Sample.AppHost/PostgreSqlHealthCheckExtensions.cs
@@ -1,8 +1,7 @@
-namespace Sample.AppHost;
 
 using HealthChecks.NpgSql;
 
-
+namespace Sample.AppHost;
 public static class PostgreSqlHealthCheckExtensions
 {
     /// <summary>

--- a/src/Sample.AppHost/Program.cs
+++ b/src/Sample.AppHost/Program.cs
@@ -1,25 +1,29 @@
 using Projects;
-using Sample.AppHost;
 
-var builder = DistributedApplication.CreateBuilder(args);
+IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
 
-var postgres = builder.AddPostgres("postgres",
-        builder.CreateResourceBuilder(new ParameterResource("username", _ => "postgres")),
-        builder.CreateResourceBuilder(new ParameterResource("password", _ => "Password12!")))
-    .WithHealthCheck()
-    .WithDataVolume()
-    .WithPgAdmin();
+//IResourceBuilder<PostgresServerResource> postgres = builder.AddPostgres("postgres",
+//        builder.CreateResourceBuilder(new ParameterResource("username", _ => "postgres")),
+//        builder.CreateResourceBuilder(new ParameterResource("password", _ => "Password12!")))
+//    .WithHealthCheck()
+//    .WithDataVolume()
+//    .WithPgAdmin();
 
-var backEndDb = postgres.AddDatabase("sample", "sample");
+//IResourceBuilder<PostgresDatabaseResource> backEndDb = postgres.AddDatabase("sample", "sample");
 
-var backEnd = builder.AddProject<Sample_BackEnd>("SampleBackEnd")
-    .WithReference(backEndDb)
-    .WaitFor(postgres)
-    .WaitFor(backEndDb);
+IResourceBuilder<RabbitMQServerResource> rabbitMq = builder.AddRabbitMQ("messaging")
+    .WithManagementPlugin();
 
-var api = builder.AddProject<Sample_Api>("SampleApi")
-    .WithReference(backEndDb)
-    .WaitFor(postgres)
-    .WaitFor(backEndDb);
+IResourceBuilder<ProjectResource> backEnd = builder.AddProject<Sample_BackEnd>("SampleBackEnd")
+    //.WithReference(backEndDb)
+    .WithReference(rabbitMq)
+    //.WaitFor(postgres)
+    .WaitFor(rabbitMq);
+
+IResourceBuilder<ProjectResource> api = builder.AddProject<Sample_Api>("SampleApi")
+    //.WithReference(backEndDb)
+    .WithReference(rabbitMq)
+    //.WaitFor(postgres)
+    .WaitFor(rabbitMq);
 
 builder.Build().Run();

--- a/src/Sample.AppHost/Sample.AppHost.csproj
+++ b/src/Sample.AppHost/Sample.AppHost.csproj
@@ -1,7 +1,5 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
-  
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.3.1" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
@@ -10,16 +8,12 @@
     <IsAspireHost>true</IsAspireHost>
     <UserSecretsId>9033767a-f0a0-40ca-bf8c-e539ee8e41f6</UserSecretsId>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.0.0" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="9.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="8.0.2" />
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="9.3.1" />
+    <PackageReference Include="Aspire.Hosting.RabbitMQ" Version="9.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Sample.Api\Sample.Api.csproj" />
     <ProjectReference Include="..\Sample.BackEnd\Sample.BackEnd.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/Sample.BackEnd/Sample.BackEnd.csproj
+++ b/src/Sample.BackEnd/Sample.BackEnd.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Worker">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit.SqlTransport.PostgreSQL" Version="8.3.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="8.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sample.Components/OrderManagement/ProcessOrderConsumer.cs
+++ b/src/Sample.Components/OrderManagement/ProcessOrderConsumer.cs
@@ -1,10 +1,11 @@
-namespace Sample.Components.OrderManagement;
 
 using Contracts;
+
 using MassTransit;
+
 using Microsoft.Extensions.Logging;
 
-
+namespace Sample.Components.OrderManagement;
 public class ProcessOrderConsumer :
     IConsumer<ProcessOrder>
 {

--- a/src/Sample.Components/Sample.Components.csproj
+++ b/src/Sample.Components/Sample.Components.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MassTransit" Version="8.3.2" />
+    <PackageReference Include="MassTransit" Version="8.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Sample.ServiceDefaults/Sample.ServiceDefaults.csproj
+++ b/src/Sample.ServiceDefaults/Sample.ServiceDefaults.csproj
@@ -1,22 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsAspireSharedProject>true</IsAspireSharedProject>
   </PropertyGroup>
-
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-
-    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
+    <PackageReference Include="Microsoft.Extensions.ServiceDiscovery" Version="9.3.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Switch to RabbitMQ for MassTransit transport

Updated the message transport configuration to use RabbitMQ instead of PostgreSQL in the MassTransit setup. This change includes replacing the `AddSqlMessageScheduler` with `AddDelayedMessageScheduler` and modifying the connection string accordingly.

Additionally, project files have been updated to reflect the new dependencies, including upgrading the MassTransit package to version 8.5.0. The health check annotations and extensions have been adjusted for compatibility with the new transport. Significant refactoring has been done in `Program.cs`, and the `CustomerNumberPartitionKeyFilter` and `ProcessOrderConsumer` classes have been improved for clarity and maintainability. The `Sample.ServiceDefaults.csproj` file has also been updated to include newer versions of OpenTelemetry packages.